### PR TITLE
CDP-832: Update to match new API schema, add alt text to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,23 @@ Determines what content is pulled
 | categories   | Categories associated with element |
 
 
-#### Display options 
-Deetermines how the content is displayed. All display options are added under a `ui` property in the configuration object.  See [usage](#usage) for an example.
+#### Display options
+Determines how the content is displayed. All display options are added under a `ui` property in the configuration object. See [usage](#usage) for an example.
 
 | Option | Description |
 | ------ | ----------- |
-| layout   | How should properties within component lay themeselvesout: default or blog style |
+| layout    | How should properties within component lay themeselves out: default or blog style |
 | direction | Direction of feed: row (default) or column |
-| image    | Thumbnail image that appears in the feed |
-| image -> shape   | Shape of image: rectangle (default) or circle |
+| image     | Thumbnail image that appears in the feed |
+| image -> shape | Shape of image: rectangle (default) or circle |
 | image -> width | Width of image |
-| image -> borderWidth  |  Width of image border |
-| image -> borderColor   | Color of image border |
-| image -> borderStyle  | Style of image border (standard html border styles)  |
+| image -> borderWidth |  Width of image border |
+| image -> borderColor | Color of image border |
+| image -> borderStyle | Style of image border (standard html border styles) |
 
 ## Usage
 
-Laod the css and js article feed files and then initialize the article feed widget. NOTE: as this widget is currently under development, the css and js file locations will move.
+Load the css and js article feed files and then initialize the article feed widget. NOTE: as this widget is currently under development, the css and js file locations will move.
 
 `https://s3.amazonaws.com/iip-design-stage-modules/modules/cdp-module-article-feed/cdp-module-article-feed.min.css`
 `https://s3.amazonaws.com/iip-design-stage-modules/modules/cdp-module-article-feed/cdp-module-article-feed.min.js`
@@ -58,9 +58,9 @@ Laod the css and js article feed files and then initialize the article feed widg
 ```js
   CDP.widgets.ArticleFeed.new({
     selector: '#articleFeed',
-    sites: 'share.america.gov', 
-    size: '3', 
-    types: 'post', 
+    sites: 'share.america.gov',
+    size: '3',
+    types: 'post',
     langs: 'en-US',
     tags: 'crowdfunding, startups',
     categories: 'business',  

--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
             CDP.widgets.ArticleFeed.new({
               selector: '#feed1',
               sites: 'yali.dev.america.gov,courses.staging.america.gov', 
-              //ids: ["4168","6297","13245"],
+              ids: ["16885","16805","13245"],
               size: '3', 
               types: '', 
               langs: '',
@@ -56,8 +56,8 @@
                 direction: 'row',
                 textAlignment: 'center',
                 image: {
-                  shape: 'circle',
-                  width: '10',
+                  shape: 'rectangle',
+                  width: '',
                   borderWidth: '',             
                   borderColor: '#192856',
                   borderStyle: 'solid'
@@ -77,8 +77,8 @@
 
             CDP.widgets.ArticleFeed.new({
               selector: '#feed2',
-              sites: 'yali.dev.america.gov,courses.staging.america.gov', 
-              ids: ["4168","6297","13245"],
+              sites: 'yali.dev.america.gov,share.dev.america.gov', 
+              ids: ["4168","6297","534496"],
               size: '3', 
               types: '', 
               langs: '',
@@ -86,7 +86,7 @@
               categories: '',
               meta: ['tags', 'author', 'date'],
               ui: {
-                layout: '',
+                layout: 'blog',
                 direction: 'row',
                 textAlignment: 'center',
                 openLinkInNewWin: false,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,7 +3,7 @@ import { FETCH_ARTICLES,
          FETCH_ARTICLES_SUCCESS,
          FETCH_ARTICLES_FAILURE } from "../actions/types";
 
-const CDP_PUBLIC_API = 'https://api.dev.america.gov/v1/search';  
+const CDP_PUBLIC_API = `${process.env.REACT_APP_CDP_PUBLIC_API}/v1/search`;  
 
 export function fetchArticles( query ) {
   const request = axios.post( CDP_PUBLIC_API, query );

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { FETCH_ARTICLES, 
-         FETCH_ARTICLES_SUCCESS, 
-         FETCH_ARTICLES_FAILURE } from "../actions/types"; 
+import { FETCH_ARTICLES,
+         FETCH_ARTICLES_SUCCESS,
+         FETCH_ARTICLES_FAILURE } from "../actions/types";
 
-const CDP_PUBLIC_API = `${process.env.REACT_APP_CDP_PUBLIC_API}/v1/search`;  
+const CDP_PUBLIC_API = 'https://api.dev.america.gov/v1/search';  
 
 export function fetchArticles( query ) {
   const request = axios.post( CDP_PUBLIC_API, query );

--- a/src/components/list_blog_item.jsx
+++ b/src/components/list_blog_item.jsx
@@ -31,12 +31,14 @@ const BlogListItem = ( props ) => {
     minHeight:  props.ui.image.width
   }
 
+  const imageAlt = ( ( article.thumbnail || {} ).alt || ' ' );
+
   return (
     <li className="article-item" style={ articleStyle } data-id={ article.post_id }>
       <div className="article-media">
         <div className={ imageWrapperCls } style={ getImageWrapperStyle(props.ui.image.shape) }>
           <a rel="noopener noreferrer" href={ article.link } target={ props.ui.openLinkInNewWin }>
-            <span className="article-image" style={ imageStyle }></span>
+            <span className="article-image" style={ imageStyle } role="img" aria-label={ imageAlt }></span>
           </a>
         </div>
       </div>

--- a/src/components/list_default_item.jsx
+++ b/src/components/list_default_item.jsx
@@ -27,6 +27,8 @@ const DefaultListItem = ( props ) => {
     minHeight:  props.ui.image.width
   }
 
+  const imageAlt = ( ( article.thumbnail || {} ).alt || ' ' );
+
   // const contentStyle = {
   //   textAlign: props.ui.textAlignment
   // }
@@ -36,7 +38,7 @@ const DefaultListItem = ( props ) => {
       <div className="article-media">
         <div className={ imageWrapperCls } style={ getImageWrapperStyle(props.ui.image.shape) }>
           <a rel="noopener noreferrer" href={ article.link } target={ props.ui.openLinkInNewWin }>
-            <span className="article-image" style={ imageStyle }></span>
+            <span className="article-image" style={ imageStyle } role="img" aria-label={ imageAlt }></span>
           </a>
         </div>
       </div>

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -13,8 +13,8 @@ let placeholderImages = {
 
 export const getImage = ( article, minHeight = 0 ) => {
   let image;
-  if ( article.thumbnail ) {
-    image = getImageSize( article.thumbnail, minHeight );
+  if ( article.thumbnail && article.thumbnail.sizes ) {
+    image = getImageSize( article.thumbnail.sizes, minHeight );
   }  
   if( !image ) {
     image = getPlaceHolderImage( article );


### PR DESCRIPTION
Looks for images in the thumbnail.sizes object.
Uses the thumbnails.alt property to populate an aria-label alt field for feed images.